### PR TITLE
Iterating xor

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,11 +5,7 @@ on:
     push:
       branches: [ "main" ]
       paths:
-        - 'docs/**'
         - 'src/toy_crypto/__about__.py'
-
-    pull_request:
-      branches: [ "main" ]
 
 jobs:
   pages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `utils.hamming_distance()` is now a thing.
 - `vigenere.probable_keysize()` is also now a thing.
-- `utils.ixor()` for in-place xor.
+- `utils.xor()` can take an Iterator[int] has a message, so the entire message does not need to be stored
+- The `utils.Xor` class creates an Iterator of xoring a message and a pad.
   
 ### Improved
 

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -7,8 +7,10 @@ This module is imported with:
 
     import toy_crypto.utils
 
+.. currentmodule:: toy_crypto.utils
 
-.. autofunction:: toy_crypto.utils.digit_count
+
+.. autofunction:: digit_count
 
 Coding this is a math problem, not a string representation problem.
 Idetally the solution would be to use
@@ -36,7 +38,7 @@ of :py:func:`math.log`.
 >>> digit_count(-10_000)
 5
 
-.. autofunction:: toy_crypto.utils.lsb_to_msb
+.. autofunction:: lsb_to_msb
 
 :func:`~toy_crypto.utils.lsb_to_msb` is used by
 :func:`~toy_crypto.ec.Point.scaler_multiply` and would be used by modular exponentiation
@@ -48,18 +50,7 @@ through side channels.
 [1, 0, 1, 1]
 
 
-.. autofunction:: toy_crypto.utils.xor
-
->>> from toy_crypto.utils import xor
->>> message = b"Attack at dawn!"
->>> pad = bytes(10) + bytes.fromhex("00 14 04 05 00")
->>> modified_message = xor(message, pad)
->>> modified_message
-b'Attack at dusk!'
-
-.. autofunction:: toy_crypto.utils.ixor
-
-.. autofunction:: toy_crypto.utils.hamming_distance
+.. autofunction:: hamming_distance
 
 Let's illustrate with an `example from Cryptopals <https://cryptopals.com/sets/1/challenges/6>`__.
 
@@ -68,6 +59,38 @@ Let's illustrate with an `example from Cryptopals <https://cryptopals.com/sets/1
 >>> s2 = b"wokka wokka!!!"
 >>> hamming_distance(s1, s2)
 37
- 
-.. autoclass:: toy_crypto.utils.Rsa129
+
+
+xor
+-----
+
+The :func:`utils.xor` and the class :class:`utils.Xor` provide utilities for xoring strings of bytes together. There is some assymetry between the two arguments. The ``message`` can be an :py:class:`collections.abc.Iterator` as well as :py:class:`bytes`. The ``pad`` arguement on the other hand, is expected to be :py:class:`bytes` only (in this version.) The ``pad`` argument is will be repeated if it is shorter than the message.
+
+.. warning::
+
+    The :type:`~toy_crypto.types.Byte` type is just a type alias for :py:class:`int`. There is no run time nor type checking mechanism that prevents you from passing an ``Iterator[Byte]`` message that contains integers outside of the range that would be expected for a byte.
+    If you do so, bad things will happen. If you are lucky some exception from the bowels of Python will be raised in a way that will help you identify the error. If you are unlucky, you will silently get garbage results.
+
+.. autoclass:: Xor
+    :class-doc-from: both
+    :members:
+
+.. autofunction:: xor
+
+>>> from toy_crypto.utils import xor
+>>> message = b"Attack at dawn!"
+>>> pad = bytes(10) + bytes.fromhex("00 14 04 05 00")
+>>> modified_message = xor(message, pad)
+>>> modified_message
+b'Attack at dusk!'
+
+
+Encodings for the RSA 129 challenge
+-------------------------------------
+
+When the RSA 129 challenge was first published in *Scientific American* in 1979
+it used its own encoding scheme between text and integers.
+This class provides an encoder and decoder for that scheme.
+
+.. autoclass:: Rsa129
     :members:

--- a/src/toy_crypto/types.py
+++ b/src/toy_crypto/types.py
@@ -18,3 +18,13 @@ def is_positive_int(val: Any) -> TypeGuard[PositiveInt]:
     if not isinstance(val, int):
         return False
     return val >= 1
+
+
+Byte = NewType("Byte", int)
+
+
+def is_byte(val: Any) -> TypeGuard[Byte]:
+    """True iff val is int s.t. 0 <= val < 256."""
+    if not isinstance(val, int):
+        return False
+    return 0 <= val and val < 256

--- a/src/toy_crypto/types.py
+++ b/src/toy_crypto/types.py
@@ -20,10 +20,10 @@ def is_positive_int(val: Any) -> TypeGuard[PositiveInt]:
     return val >= 1
 
 
-Byte = NewType("Byte", int)
+Byte = int
 
 
-def is_byte(val: Any) -> TypeGuard[Byte]:
+def is_byte(val: Any) -> bool:
     """True iff val is int s.t. 0 <= val < 256."""
     if not isinstance(val, int):
         return False

--- a/src/toy_crypto/utils.py
+++ b/src/toy_crypto/utils.py
@@ -1,6 +1,5 @@
 """Utility functions"""
 
-import itertools
 from collections.abc import Iterator
 from typing import Optional, Self
 
@@ -67,7 +66,7 @@ class Xor:
         Why does it spit out ints instead of bytes?
         Because although python thinks a single element
         of a str is a str, it thinks that a single
-        element of a bytes object is an int. 
+        element of a bytes object is an int.
         """
         # Convert message to Iterator if needed
         self._message = message.__iter__()

--- a/src/toy_crypto/utils.py
+++ b/src/toy_crypto/utils.py
@@ -104,18 +104,6 @@ def xor(
     return r
 
 
-def ixor(m: bytearray, pad: bytes | bytearray) -> None:
-    """In place xor. Replaces m with the xor of m with a (repeated) pad.
-
-    The pad is repeated if it is shorter than m.
-    """
-
-    xorIt = Xor(m, pad)
-    for i, b in enumerate(xorIt):
-        m[i] = b
-    return
-
-
 def hamming_distance(a: bytes, b: bytes) -> int:
     """Hamming distance between byte sequences of equal length.
 

--- a/src/toy_crypto/utils.py
+++ b/src/toy_crypto/utils.py
@@ -1,6 +1,7 @@
 """Utility functions"""
 
 from collections.abc import Iterator
+import itertools
 from typing import Optional, Self
 from toy_crypto.types import Byte
 
@@ -51,57 +52,40 @@ def digit_count(n: int, base: int = 10) -> int:
 
 
 class Xor:
+    """Iterator that spits out xor of message with (repeated) pad.
+
+    The iterator will run through successful bytes of message
+    xor-ing those with successive bytes of pad, repeating
+    pad if pad is shorter than message.
+
+    Each iteration returns a non-negative int less than 256.
+    """
+
     def __init__(
         self,
-        message: Iterator[Byte] | bytes | bytearray,
-        pad: bytes | bytearray,
+        message: Iterator[Byte] | bytes,
+        pad: bytes,
     ) -> None:
-        """Iterator that spits out xor of message with (repeated) pad.
-
-        The iterator will run through successful bytes of message
-        xor-ing those with successive bytes of pad, repeating
-        pad if pad is shorter than message.
-
-        Each iteration returns a non-negative int less than 256.
-
-        Why does it spit out ints instead of bytes?
-        Because although python thinks a single element
-        of a str is a str, it thinks that a single
-        element of a bytes object is an int.
-        """
         # Convert message to Iterator if needed
-        self._message = message.__iter__()
-
-        # We don't want our pad changing on us.
-        self._pad = bytes(pad)
-
-        self._pad_index: int = 0
-        self._modulus: int = len(self._pad)
+        self._message = iter(message)
+        self._pad = itertools.cycle(pad)
 
     def __next__(self) -> Byte:
-        b = self._message.__next__()
-        p = self._pad[self._pad_index]
-
-        self._pad_index = (self._pad_index + 1) % self._modulus
+        b, p = next(zip(self._message, self._pad))
         return Byte(b ^ p)
 
     def __iter__(self: Self) -> Self:
         return self
 
 
-def xor(
-    m: bytes | bytearray | Iterator[Byte], pad: bytes | bytearray
-) -> bytes:
+def xor(message: bytes | Iterator[Byte], pad: bytes) -> bytes:
     """Returns the xor of m with a (repeated) pad.
 
     The pad is repeated if it is shorter than m.
     This can be thought of as bytewise Vigenère.
-
-    This does not mutate inputs.
     """
 
-    r = bytes([b for b in Xor(m, pad)])
-    return r
+    return bytes([b for b in Xor(message, pad)])
 
 
 def hamming_distance(a: bytes, b: bytes) -> int:

--- a/src/toy_crypto/utils.py
+++ b/src/toy_crypto/utils.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Iterator
 from typing import Optional, Self
+from toy_crypto.types import Byte
 
 
 def lsb_to_msb(n: int) -> Iterator[int]:
@@ -52,7 +53,7 @@ def digit_count(n: int, base: int = 10) -> int:
 class Xor:
     def __init__(
         self,
-        message: Iterator[int] | bytes | bytearray,
+        message: Iterator[Byte] | bytes | bytearray,
         pad: bytes | bytearray,
     ) -> None:
         """Iterator that spits out xor of message with (repeated) pad.
@@ -77,18 +78,20 @@ class Xor:
         self._pad_index: int = 0
         self._modulus: int = len(self._pad)
 
-    def __next__(self) -> int:
+    def __next__(self) -> Byte:
         b = self._message.__next__()
         p = self._pad[self._pad_index]
 
         self._pad_index = (self._pad_index + 1) % self._modulus
-        return b ^ p
+        return Byte(b ^ p)
 
     def __iter__(self: Self) -> Self:
         return self
 
 
-def xor(m: bytes | bytearray | Iterator[int], pad: bytes | bytearray) -> bytes:
+def xor(
+    m: bytes | bytearray | Iterator[Byte], pad: bytes | bytearray
+) -> bytes:
     """Returns the xor of m with a (repeated) pad.
 
     The pad is repeated if it is shorter than m.

--- a/src/toy_crypto/utils.py
+++ b/src/toy_crypto/utils.py
@@ -52,7 +52,7 @@ def digit_count(n: int, base: int = 10) -> int:
 class Xor:
     def __init__(
         self,
-        message: Iterator[bytes] | bytes | bytearray,
+        message: Iterator[int] | bytes | bytearray,
         pad: bytes | bytearray,
     ) -> None:
         """Iterator that spits out xor of message with (repeated) pad.
@@ -79,20 +79,16 @@ class Xor:
 
     def __next__(self) -> int:
         b = self._message.__next__()
-        if isinstance(b, int):
-            bi = b
-        else:
-            bi = int.from_bytes(b)
-
         p = self._pad[self._pad_index]
+
         self._pad_index = (self._pad_index + 1) % self._modulus
-        return bi ^ p
+        return b ^ p
 
     def __iter__(self: Self) -> Self:
         return self
 
 
-def xor(m: bytes | bytearray, pad: bytes | bytearray) -> bytes:
+def xor(m: bytes | bytearray | Iterator[int], pad: bytes | bytearray) -> bytes:
     """Returns the xor of m with a (repeated) pad.
 
     The pad is repeated if it is shorter than m.

--- a/src/toy_crypto/utils.py
+++ b/src/toy_crypto/utils.py
@@ -67,8 +67,8 @@ class Xor:
         pad: bytes,
     ) -> None:
         # Convert message to Iterator if needed
-        self._message = iter(message)
-        self._pad = itertools.cycle(pad)
+        self._message: Iterator[Byte] = iter(message)
+        self._pad: Iterator[Byte] = itertools.cycle(pad)
 
     def __next__(self) -> Byte:
         b, p = next(zip(self._message, self._pad))
@@ -79,12 +79,11 @@ class Xor:
 
 
 def xor(message: bytes | Iterator[Byte], pad: bytes) -> bytes:
-    """Returns the xor of m with a (repeated) pad.
+    """Returns the xor of message with a (repeated) pad.
 
     The pad is repeated if it is shorter than m.
     This can be thought of as bytewise Vigenère.
     """
-
     return bytes([b for b in Xor(message, pad)])
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 import sys
 
 import pytest
+from collections.abc import Iterator
 from toy_crypto import utils
+from toy_crypto.types import Byte
 
 
 class TestUtils:
@@ -34,6 +36,15 @@ class TestUtils:
             bits = [bit for bit in utils.lsb_to_msb(n)]
             assert bits == expected
 
+    def test_hamming(self) -> None:
+        s1 = b"this is a test"
+        s2 = b"wokka wokka!!!"
+
+        hd = utils.hamming_distance(s1, s2)
+        assert hd == 37
+
+
+class TestXor:
     def test_xor(self) -> None:
         vectors = [
             (b"dusk", b"dawn", bytes.fromhex("00 14 04 05")),
@@ -53,32 +64,24 @@ class TestUtils:
             r = utils.xor(x, y)
             assert r == pad
 
-    def test_ixor(self) -> None:
-        vectors = [
-            (b"dusk", b"dawn", bytes.fromhex("00 14 04 05")),
-            (
-                b"Attack at dawn!",
-                bytes(10) + bytes.fromhex("00 14 04 05 00"),
-                b"Attack at dusk!",
-            ),
-            (
-                bytes(15),
-                bytes.fromhex("00 01 02"),
-                bytes.fromhex("00 01 02") * 5,
-            ),
-        ]
+    def test_iter(self) -> None:
+        pad = bytes.fromhex("00 36 5C")
+        p_modulus = len(pad)
+        single = list(range(0, 256))
+        s_modulus = len(single)
+        message: Iterator[Byte] = iter(single * 10)
 
-        for x, y, pad in vectors:
-            x = bytearray(x)
-            utils.ixor(x, y)
-            assert x == pad
+        iter_xor = utils.Xor(message, pad)
 
-    def test_hamming(self) -> None:
-        s1 = b"this is a test"
-        s2 = b"wokka wokka!!!"
+        m_idx = 0
+        p_idx = 0
+        for b in iter_xor:
+            expected = (m_idx % s_modulus) ^ pad[p_idx]
+            assert b == expected
+            m_idx += 1
+            p_idx = (p_idx + 1) % p_modulus
 
-        hd = utils.hamming_distance(s1, s2)
-        assert hd == 37
+        assert m_idx == s_modulus * 10
 
 
 if __name__ == "__main__":

--- a/tests/test_vigenere.py
+++ b/tests/test_vigenere.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from toy_crypto import vigenere
 
-probabistic = pytest.mark.skip(reason="Expensive and probabilistic")
+probabistic = pytest.mark.skip(reason="Probabilistic")
 
 Letter = vigenere.Letter
 


### PR DESCRIPTION
To allow for large amounts of data to be xor-ed against a pad, utils.xor can take an Iterator, and Xor produces an Iterator.

Things that may not be cool with this.

1. `Xor` is a class, so I have named it as I would a class, but is this conventional.
2. The Iterator type is `Iterator[int]` with no real enforcement that the ints are valid for bytes.

Still I am almost certainly going to approve my own pull request.