### PR TITLE
PyData Sphinx theme

### DIFF
--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -58,3 +58,6 @@ Wycheproof
 tcId
 pydata
 navbar
+ec
+nt
+vigenere

--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -61,3 +61,9 @@ navbar
 ec
 nt
 vigenere
+sidebar-nav-bs.html
+fontawesome
+page-toc
+sourcelink
+sphinx_reredirects
+pypi

--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -57,3 +57,4 @@ sympy
 Wycheproof
 tcId
 pydata
+navbar

--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -56,3 +56,4 @@ Pornin
 sympy
 Wycheproof
 tcId
+pydata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Documentation re-organization.
+- Documentation uses [PyData theme](https://pydata-sphinx-theme.readthedocs.io/).
+
 ## 0.4.2 2025-06-30
 
 ### Added

--- a/docs/source/_static/pypi-logo-no-text.svg
+++ b/docs/source/_static/pypi-logo-no-text.svg
@@ -1,0 +1,765 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="65.812035"
+   height="58"
+   viewBox="0 0 65.812035 58.000001"
+   id="svg4492"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="logo-small.svg">
+  <defs
+     id="defs4494" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.979899"
+     inkscape:cx="34.163611"
+     inkscape:cy="5.224554"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:window-width="1600"
+     inkscape:window-height="836"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata4497">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-102.23636,-759.89403)">
+    <g
+       transform="matrix(0.59931016,0,0,0.59931016,-87.829325,346.0436)"
+       id="g7132"
+       inkscape:export-xdpi="81.836845"
+       inkscape:export-ydpi="81.836845">
+      <g
+         id="g4913"
+         transform="translate(-2257.2276,-96.96281)">
+        <g
+           id="g4915"
+           style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+           transform="matrix(4.8845054,0,0,4.8845054,3516.0799,527.1875)">
+          <path
+             d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             id="path4917"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             id="path4919"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             id="path4921"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+             style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="path4923"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z"
+             style="fill:#ffffff;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="path4925"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z"
+             style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="path4927"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(4.8845053,0,0,4.8845053,3531.7032,514.40474)"
+           style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+           id="g4929">
+          <path
+             inkscape:connector-curvature="0"
+             id="path4931"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4933"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4935"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4937"
+             style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4939"
+             style="fill:#ffffff;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4941"
+             style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z" />
+        </g>
+        <g
+           id="g4943"
+           style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+           transform="matrix(4.8845053,0,0,4.8845053,3500.4564,551.33268)">
+          <path
+             d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             id="path4945"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             id="path4947"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             id="path4949"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+             style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="path4951"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z"
+             style="fill:#ffffff;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="path4953"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z"
+             style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="path4955"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4989"
+         transform="translate(-2257.2276,-96.96281)">
+        <g
+           transform="matrix(4.8845053,0,0,4.8845053,3516.0798,557.0139)"
+           style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+           id="g4991">
+          <path
+             inkscape:connector-curvature="0"
+             id="path4993"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4995"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4997"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4999"
+             style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5001"
+             style="fill:#ffffff;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5003"
+             style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z" />
+        </g>
+        <g
+           id="g5005"
+           style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+           transform="matrix(4.8845053,0,0,4.8845053,3516.0798,538.54993)">
+          <path
+             d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             id="path5007"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             id="path5009"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+             style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             id="path5011"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+             style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="path5013"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z"
+             style="fill:#ffffff;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="path5015"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z"
+             style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="path5017"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           transform="matrix(1.0875356,0,0,1.0875356,-234.9615,-68.934961)"
+           id="g5019">
+          <g
+             transform="matrix(4.4913521,0,0,4.4913521,3506.5838,565.11843)"
+             style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="g5021">
+            <path
+               inkscape:connector-curvature="0"
+               id="path5023"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5025"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5027"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5029"
+               style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5031"
+               style="fill:#ffffff;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5033"
+               style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z" />
+          </g>
+          <g
+             id="g5035">
+            <g
+               transform="matrix(4.4913521,0,0,4.4913521,3492.218,570.34238)"
+               style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="g5037">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path5039"
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+                 d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path5041"
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+                 d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path5043"
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+                 d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path5045"
+                 style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+                 d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path5047"
+                 style="fill:#ffd242;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+                 d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path5049"
+                 style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+                 d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z" />
+            </g>
+            <circle
+               transform="matrix(0.93969262,-0.34202015,0,1,0,0)"
+               cy="1823.899"
+               cx="2835.2185"
+               id="circle5051"
+               style="fill:#ffffff;fill-opacity:1"
+               r="2.966594" />
+          </g>
+          <g
+             id="g5053"
+             style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             transform="matrix(4.4913521,0,0,4.4913521,3477.8522,575.56632)">
+            <path
+               d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5055"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5057"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5059"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+               style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5061"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z"
+               style="fill:#ffd242;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5063"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z"
+               style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5065"
+               inkscape:connector-curvature="0" />
+          </g>
+          <g
+             transform="matrix(4.4913521,0,0,4.4913521,3463.4863,580.79026)"
+             style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="g5067">
+            <path
+               inkscape:connector-curvature="0"
+               id="path5069"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5071"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5073"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5075"
+               style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5077"
+               style="fill:#ffffff;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5079"
+               style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z" />
+          </g>
+          <g
+             id="g5081"
+             style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             transform="matrix(4.4913521,0,0,4.4913521,3506.5838,548.14063)">
+            <path
+               d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5083"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5085"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5087"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+               style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5089"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z"
+               style="fill:#ffd242;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5091"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z"
+               style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5093"
+               inkscape:connector-curvature="0" />
+          </g>
+          <g
+             transform="matrix(4.4913521,0,0,4.4913521,3506.5838,531.16282)"
+             style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="g5095">
+            <path
+               inkscape:connector-curvature="0"
+               id="path5097"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5099"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5101"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5103"
+               style="fill:#ffc91d;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5105"
+               style="fill:#ffd242;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5107"
+               style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z" />
+          </g>
+          <g
+             transform="matrix(4.4913521,0,0,4.4913521,3492.218,553.36457)"
+             style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="g5109">
+            <path
+               inkscape:connector-curvature="0"
+               id="path5111"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5113"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5115"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5117"
+               style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5119"
+               style="fill:#ffd242;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5121"
+               style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z" />
+          </g>
+          <g
+             id="g5123"
+             style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             transform="matrix(4.4913521,0,0,4.4913521,3492.218,536.38676)">
+            <path
+               d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5125"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5127"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5129"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+               style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5131"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z"
+               style="fill:#3775a9;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5133"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z"
+               style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5135"
+               inkscape:connector-curvature="0" />
+          </g>
+          <g
+             transform="matrix(4.4913521,0,0,4.4913521,3492.218,519.40896)"
+             style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="g5137">
+            <path
+               inkscape:connector-curvature="0"
+               id="path5139"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5141"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5143"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5145"
+               style="fill:#2f6491;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5147"
+               style="fill:#3775a9;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5149"
+               style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z" />
+          </g>
+          <g
+             id="g5151"
+             style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             transform="matrix(4.4913521,0,0,4.4913521,3477.8522,558.58851)">
+            <path
+               d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5153"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5155"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5157"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+               style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5159"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z"
+               style="fill:#ffd242;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5161"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z"
+               style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5163"
+               inkscape:connector-curvature="0" />
+          </g>
+          <g
+             transform="matrix(4.4913521,0,0,4.4913521,3477.8522,541.6107)"
+             style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="g5165">
+            <path
+               inkscape:connector-curvature="0"
+               id="path5167"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5169"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5171"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5173"
+               style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5175"
+               style="fill:#3775a9;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5177"
+               style="fill:#efeeea;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z" />
+          </g>
+          <g
+             transform="matrix(4.4913521,0,0,4.4913521,3463.4863,563.81245)"
+             style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             id="g5179">
+            <path
+               inkscape:connector-curvature="0"
+               id="path5181"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5183"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5185"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5187"
+               style="fill:#f7f7f4;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5189"
+               style="fill:#3775a9;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path5191"
+               style="fill:#2f6491;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z" />
+          </g>
+          <g
+             id="g5193"
+             style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+             transform="matrix(4.4913521,0,0,4.4913521,3463.4863,546.83464)">
+            <path
+               d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5195"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5197"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+               id="path5199"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z"
+               style="fill:#2f6491;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5201"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z"
+               style="fill:#3775a9;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5203"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z"
+               style="fill:#2f6491;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="path5205"
+               inkscape:connector-curvature="0" />
+          </g>
+          <g
+             id="g5207">
+            <g
+               transform="matrix(4.4913521,0,0,4.4913521,3477.8522,524.6329)"
+               style="fill:#a29d86;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+               id="g5209">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path5211"
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e9e9ff;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+                 d="m -186.32897,59.726319 3.18465,1.159119 0,3.742997 -3.18465,-1.159119 z" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path5213"
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#353564;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+                 d="m -189.56075,60.902593 0,3.742997 3.23178,-1.176274 0,-3.742997 z" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path5215"
+                 style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#afafde;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.07269443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+                 d="m -189.56075,64.64559 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path5217"
+                 style="fill:#2f6491;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+                 d="m -189.56075,60.902593 3.18465,1.159118 3.23178,-1.176273 -3.18465,-1.159119 z" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path5219"
+                 style="fill:#3775a9;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+                 d="m -186.3761,62.061711 0,3.742997 3.23178,-1.176273 0,-3.742997 z" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path5221"
+                 style="fill:#2f6491;fill-opacity:1;stroke:#cccccc;stroke-width:0.07269443;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+                 d="m -189.56075,60.902593 3.18465,1.159118 0,3.742997 -3.18465,-1.159118 z" />
+            </g>
+            <circle
+               transform="matrix(0.93969262,-0.34202015,0,1,0,0)"
+               cy="1772.9225"
+               cx="2816.0166"
+               id="circle5223"
+               style="fill:#ffffff;fill-opacity:1"
+               r="2.966594" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/source/bibliography.rst
+++ b/docs/source/bibliography.rst
@@ -1,4 +1,4 @@
-bibliography
+Bibliography
 =============
 
 .. bibliography::

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ with open("../../pyproject.toml", "rb") as f:
 
 pyproject = toml["project"]
 
-project = pyproject["name"]
+project = "ToyCrypto"
 release = version
 author = ",".join([author["name"] for author in pyproject["authors"]])
 copyright = f"2024–2025 {author}"
@@ -112,7 +112,6 @@ autodoc_show_sourcelink = True
 extensions.append("sphinx.ext.intersphinx")
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "dns": ("https://dnspython.readthedocs.io/en/stable/", None),
 }
 
 extensions.append("sphinxcontrib.bibtex")
@@ -138,6 +137,7 @@ rst_prolog = f"""
 .. _bitarray: https://github.com/ilanschnell/bitarray
 .. _pypkcs1: https://github.com/bdauvergne/python-pkcs1/
 .. _pypi: https://pypi.org/
+.. _sympy: https://www.sympy.org/
 """
 
 
@@ -146,7 +146,25 @@ rst_prolog = f"""
 
 # html_theme = "nature"
 html_theme = 'pydata_sphinx_theme'
-html_theme_options = {
-  "show_nav_level": 2
+html_sidebars = {
+    "**": [
+        "sidebar-nav-bs.html",
+    ],
+    "why/index": [],
+    "index": [],
+    "bibliography": [],
 }
+html_theme_options: dict[str, object] = {
+    "logo": {
+        "text": "ToyCrypto",
+    },
+    # page elements
+    # "navbar_start": ["project", "version"],
+    "navbar_end": ["theme-switcher", "navbar-icon-links.html"],
+    "footer_start": ["copyright", "sphinx-version"],
+    "footer_end": ["theme-version"],
+    "secondary_sidebar_items": ["page-toc", "edit-this-page", "sourcelink"],
+    "header_links_before_dropdown": 7,
+}
+
 html_static_path = ["_static"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -157,15 +157,16 @@ html_sidebars = {
 }
 html_theme_options: dict[str, object] = {
     "logo": {
-        "text": "ToyCrypto",
+        "text": f"ToyCrypto ({version})",
     },
     # page elements
-    # "navbar_start": ["project", "version"],
+    "navbar_start": ["navbar-logo"],
     "navbar_end": ["theme-switcher", "navbar-icon-links.html"],
     "footer_start": ["copyright", "sphinx-version"],
     "footer_end": ["theme-version"],
     "secondary_sidebar_items": ["page-toc", "edit-this-page", "sourcelink"],
-    "header_links_before_dropdown": 7,
+    "header_links_before_dropdown": 4,
+    "primary_sidebar_end": ["indices.html", "sidebar-ethical-ads.html"],
 }
 
 # Reorganization means some redirects.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -98,6 +98,7 @@ extensions: list[str] = [
     "sphinx_toolbox.more_autodoc.genericalias",
     "sphinx_toolbox.more_autodoc.typevars",
     # "sphinx_toolbox.more_autodoc.variables",
+    "sphinx_reredirects",
 ]
 
 autodoc_typehints = "signature"
@@ -145,7 +146,7 @@ rst_prolog = f"""
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 # html_theme = "nature"
-html_theme = 'pydata_sphinx_theme'
+html_theme = "pydata_sphinx_theme"
 html_sidebars = {
     "**": [
         "sidebar-nav-bs.html",
@@ -166,5 +167,16 @@ html_theme_options: dict[str, object] = {
     "secondary_sidebar_items": ["page-toc", "edit-this-page", "sourcelink"],
     "header_links_before_dropdown": 7,
 }
+
+# Reorganization means some redirects.
+# Sadly, I can't to 301s when hosting on github pages
+
+redirects: dict[str, str] = {
+    src: f"modules/{src}.html"
+    for src in [
+        "birthday", "bit_utils", "ec", "games", "nt", "rand",
+        "rsa", "sieve", "types", "utils", "vigenere",
+    ]
+}  # fmt: skip
 
 html_static_path = ["_static"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -160,10 +160,10 @@ html_theme_options: dict[str, object] = {
     },
     "icon_links": [
         {
-         "name": "PyPI",
-         "url": "https://pypi.org/project/toycrypto/",
-         "icon": "_static/pypi-logo-no-text.svg",
-         "type": "local",
+            "name": "PyPI",
+            "url": "https://pypi.org/project/toycrypto/",
+            "icon": "_static/pypi-logo-no-text.svg",
+            "type": "local",
         },
         {
             # Label for this link

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -145,7 +145,6 @@ rst_prolog = f"""
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-# html_theme = "nature"
 html_theme = "pydata_sphinx_theme"
 html_sidebars = {
     "**": [
@@ -161,10 +160,16 @@ html_theme_options: dict[str, object] = {
     },
     "icon_links": [
         {
+         "name": "PyPI",
+         "url": "https://pypi.org/project/toycrypto/",
+         "icon": "_static/pypi-logo-no-text.svg",
+         "type": "local",
+        },
+        {
             # Label for this link
             "name": "GitHub",
-            "url": f"https://github.com/{github_username}/{github_repository}", 
-            "icon": "fa-brands fa-square-github",
+            "url": f"https://github.com/{github_username}/{github_repository}",
+            "icon": "fa-brands fa-github",
             "type": "fontawesome",
         },
     ],

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -159,6 +159,15 @@ html_theme_options: dict[str, object] = {
     "logo": {
         "text": f"ToyCrypto ({version})",
     },
+    "icon_links": [
+        {
+            # Label for this link
+            "name": "GitHub",
+            "url": f"https://github.com/{github_username}/{github_repository}", 
+            "icon": "fa-brands fa-square-github",
+            "type": "fontawesome",
+        },
+    ],
     # page elements
     "navbar_start": ["navbar-logo"],
     "navbar_end": ["theme-switcher", "navbar-icon-links.html"],

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -144,5 +144,9 @@ rst_prolog = f"""
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "nature"
+# html_theme = "nature"
+html_theme = 'pydata_sphinx_theme'
+html_theme_options = {
+  "show_nav_level": 2
+}
 html_static_path = ["_static"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,6 @@ Table of Contents
   why/index
 
   modules/index
-
+  
   bibliography
    

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,76 +3,25 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-.. include:: ../common/unsafe.rst
+.. include:: /../common/unsafe.rst
 
 Toy cryptographic functions and utilities
 ==========================================
 
 Some toy (unsafe for actual use) cryptography related utilites.
 
-Installation
--------------
-
-Remember that nothing here is built to be used for security purposes,
-but if you must:
-
-..
-  Until https://github.com/sphinx-toolbox/sphinx-toolbox/issues/190 is resolved
-  I will not be using "sphinx_toolbox.installation",
-
-.. 
-  installation:: toycrypto
-    :pypi:
-    :github: main
-
-From pypi_ for the latest *released* version::
-
-    python3 -m pip install toycrypto --user
-
-From GitHub for the head of the main branch::
-
-    python3 -m pip install git+https://github.com/jpgoldberg/toy-crypto-math@main --user
-
     
-
-Import names
-------------
-
-Once installed, the modules are imported under ``toy_crypto``.
-For example, Number Theory module would be imported with ``import toy_crypto.nt``.
-
-
->>> from toy_crypto.nt import factor
->>> n = 69159288649
->>> factorization = factor(n)
->>> factorization.data
-[(11, 2), (5483, 1), (104243, 1)]
->>> str(factorization)
-'11^2 * 5483 * 104243'
->>> factorization.n == n
-True
->>> factorization.phi
-62860010840
-
-Note again that the `SageMath Factorization class <https://doc.sagemath.org/html/en/reference/structure/sage/structure/factorization.html>`_ is far more efficient and general than what exists in this toy cryptography module.
-
 Table of Contents 
 ------------------
 
 .. toctree::
-  :maxdepth: 3
+  :maxdepth: 2
 
-  motivation
-  utils
-  bit_utils
-  nt
-  sieve
-  rsa
-  ec
-  rand
-  games
-  birthday
-  types
-  vigenere
+  intro/quickstart
+  
+  why/index
+
+  modules/index
+
   bibliography
    

--- a/docs/source/intro/quickstart.rst
+++ b/docs/source/intro/quickstart.rst
@@ -1,0 +1,64 @@
+
+.. include:: /../common/unsafe.rst
+
+Get Started
+==========================================
+
+Installation
+-------------
+
+Remember that nothing here is built to be used for security purposes,
+but if you must:
+
+..
+  Until https://github.com/sphinx-toolbox/sphinx-toolbox/issues/190 is resolved
+  I will not be using "sphinx_toolbox.installation",
+
+.. 
+  installation:: toycrypto
+    :pypi:
+    :github: main
+
+From pypi_ for the latest *released* version::
+
+    python3 -m pip install toycrypto --user
+
+From GitHub for the head of the main branch::
+
+    python3 -m pip install git+https://github.com/jpgoldberg/toy-crypto-math@main --user
+
+Note that the major version number is 0. Things here may change in breaking ways.
+    
+Dependencies
+------------
+
+|project| can operate in pure Python environments
+although some *optional* third party dependencies may
+non-Python bindings.
+
+The only required depedency is primefac_, which many utilities here wrap.
+Though I might change that to SymPy_, now that I have learned it is pure python.
+
+bitarray_ is an optional third party dependency that involves C bindings.
+
+Import names
+------------
+
+Once installed, the modules are imported under ``toy_crypto``.
+For example, :mod:`Number Theory module <nt>`
+would be imported with ``import toy_crypto.nt``.
+
+
+>>> from toy_crypto.nt import factor
+>>> n = 69159288649
+>>> factorization = factor(n)
+>>> factorization.data
+[(11, 2), (5483, 1), (104243, 1)]
+>>> str(factorization)
+'11^2 * 5483 * 104243'
+>>> factorization.n == n
+True
+>>> factorization.phi
+62860010840
+
+Note again that the `SageMath Factorization class <https://doc.sagemath.org/html/en/reference/structure/sage/structure/factorization.html>`_ is far more efficient and general than what exists in this toy cryptography module.

--- a/docs/source/modules/birthday.rst
+++ b/docs/source/modules/birthday.rst
@@ -1,4 +1,4 @@
-.. include:: ../common/unsafe.rst
+.. include:: /../common/unsafe.rst
 
 Birthday Paradox Computations
 ================================

--- a/docs/source/modules/bit_utils.rst
+++ b/docs/source/modules/bit_utils.rst
@@ -1,4 +1,4 @@
-.. include:: ../common/unsafe.rst
+.. include:: /../common/unsafe.rst
 
 Bit manipulation utiltieis
 ===========================

--- a/docs/source/modules/ec.rst
+++ b/docs/source/modules/ec.rst
@@ -1,4 +1,4 @@
-.. include:: ../common/unsafe.rst
+.. include:: /../common/unsafe.rst
 
 Elliptic curves
 ================

--- a/docs/source/modules/games.rst
+++ b/docs/source/modules/games.rst
@@ -1,4 +1,4 @@
-.. include:: ../common/unsafe.rst
+.. include:: /../common/unsafe.rst
 
 *****************
 Security games

--- a/docs/source/modules/index.rst
+++ b/docs/source/modules/index.rst
@@ -1,0 +1,29 @@
+The modules
+===========
+
+There are a number distinct modules for playing with different Cryptographic concepts.
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Main modules
+
+    nt
+    sieve
+    birthday
+    rsa
+    ec
+    games
+    vigenere
+    
+
+Some modules contain utilities which are imported by other modules.
+
+
+.. toctree:: 
+    :caption: Utility modules
+    :maxdepth: 2
+
+    rand
+    utils
+    bit_utils
+    types

--- a/docs/source/modules/nt.rst
+++ b/docs/source/modules/nt.rst
@@ -1,4 +1,4 @@
-.. include:: ../common/unsafe.rst
+.. include:: /../common/unsafe.rst
 
 Number Theory
 ==============

--- a/docs/source/modules/rand.rst
+++ b/docs/source/modules/rand.rst
@@ -1,4 +1,4 @@
-.. include:: ../common/unsafe.rst
+.. include:: /../common/unsafe.rst
 
 Random Numbers
 ================

--- a/docs/source/modules/rsa.rst
+++ b/docs/source/modules/rsa.rst
@@ -1,4 +1,4 @@
-.. include:: ../common/unsafe.rst
+.. include:: /../common/unsafe.rst
 
 ***************
 RSA

--- a/docs/source/modules/sieve.rst
+++ b/docs/source/modules/sieve.rst
@@ -1,4 +1,4 @@
-.. include:: ../common/unsafe.rst
+.. include:: /../common/unsafe.rst
 
 Sieve of Eratosthenes
 ======================
@@ -55,7 +55,7 @@ It turns out that using native Python integers was enormously slower than I coul
 
 .. _all_figure:
 
-.. figure:: images/all_data.png
+.. figure:: /images/all_data.png
     :alt: Graph showing that IntSieve creation time is really slow
 
     Seconds to create sieves
@@ -69,7 +69,7 @@ So here is a graph showing the times just for :class:`BaSieve` and a :class:`Set
 
 .. _sans_int_figure: 
 
-.. figure:: images/sans_int.png
+.. figure:: /images/sans_int.png
     :alt: Graph showing that Sieve is more efficient than SetSeive
 
     Seconds to create sieves (without IntSieve).

--- a/docs/source/modules/types.rst
+++ b/docs/source/modules/types.rst
@@ -1,4 +1,4 @@
-.. include:: ../common/unsafe.rst
+.. include:: /../common/unsafe.rst
 
 Types
 ==============

--- a/docs/source/modules/utils.rst
+++ b/docs/source/modules/utils.rst
@@ -1,4 +1,4 @@
-.. include:: ../common/unsafe.rst
+.. include:: /../common/unsafe.rst
 
 Utility functions
 =================

--- a/docs/source/modules/vigenere.rst
+++ b/docs/source/modules/vigenere.rst
@@ -1,4 +1,4 @@
-.. include:: ../common/unsafe.rst
+.. include:: /../common/unsafe.rst
 
 Vigenère cipher
 ===============

--- a/docs/source/why/index.rst
+++ b/docs/source/why/index.rst
@@ -1,4 +1,4 @@
-.. include:: ../common/unsafe.rst
+.. include:: /../common/unsafe.rst
 
 Motiviation
 ===========

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ docs = [
     "sphinx_autodoc_typehints",
     "sphinx-toolbox>=3.10.0",
     "sphinxcontrib-bibtex>=2.6.4",
+    "sphinx-reredirects>=1.0.0",
 ]
 prof = [
     "matplotlib>=3.10.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1100,6 +1100,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-reredirects"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/61/d3039bc2b688c73e81f515afe771b7cc9631dfef63b3e3ac3aab3d73c685/sphinx_reredirects-1.0.0.tar.gz", hash = "sha256:7c9bada9f1330489fcf4c7297a2d6da2a49ca4877d3f42d1388ae1de1019bf5c", size = 711970 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/7f/adb886a3db417a2ccea6a13dcb4b88d08f82104aed17e347346f79480a5f/sphinx_reredirects-1.0.0-py3-none-any.whl", hash = "sha256:1d0102710a8f633c6c885f940f440f7195ada675c1739976f0135790747dea06", size = 6173 },
+]
+
+[[package]]
 name = "sphinx-tabs"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1248,6 +1260,7 @@ dev = [
 docs = [
     { name = "enum-tools", extra = ["sphinx"] },
     { name = "sphinx-autodoc-typehints" },
+    { name = "sphinx-reredirects" },
     { name = "sphinx-toolbox" },
     { name = "sphinxcontrib-bibtex" },
 ]
@@ -1281,6 +1294,7 @@ dev = [
 docs = [
     { name = "enum-tools", extras = ["sphinx"], specifier = ">=0.13.0" },
     { name = "sphinx-autodoc-typehints" },
+    { name = "sphinx-reredirects", specifier = ">=1.0.0" },
     { name = "sphinx-toolbox", specifier = ">=3.10.0" },
     { name = "sphinxcontrib-bibtex", specifier = ">=2.6.4" },
 ]


### PR DESCRIPTION
1. Switched to `pydata_sphinx_theme`
2. Reorganized docs to work with as "section" based theme
3. Lot's and lot's of configuration needed to properly make use of the theme.
4.  Re-org meant adding some redirects. With no server config controls, these are done through client stuff. Uses https://documatt.com/sphinx-reredirects/

Left for the future is figuring out a better way to deal with versions. This does not use the version switcher because I don't know how to deploy docs appropriately for that.